### PR TITLE
Fix

### DIFF
--- a/src/present.js
+++ b/src/present.js
@@ -1108,6 +1108,9 @@ var TestSuite = new(function () {
             plugin.pluginObject.getDeviceInfo(ui.device(), ui.infoType()).then(function (result) {
                 var message = result;
 
+                if (info == plugin.TOKEN_INFO_LABEL)
+                    if (message == "Rutoken ECP <no label>") message = "&lt;no label&gt;";
+
                 if (info === plugin.TOKEN_INFO_DEVICE_TYPE) {
                     message = "Невозможно определить тип устройства";
                     switch (result) {


### PR DESCRIPTION
Исправляет вывод в консоли лейбла токена, при его отсутствие, путём подмены сообщения.
т.к. по умолчанию при отсутствие лейбла выводится Rutoken ECP <no label> и при прямой записи в div консоли <no label> воспринимается как тег и не отображается.